### PR TITLE
remove TODO comments as pthread is necessary

### DIFF
--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(openkit-sample ${CURLIMPLIB} ${ZLIB_LIBRARIES})
 target_compile_definitions(openkit-sample PRIVATE -DOPENKIT_STATIC_DEFINE)
 
 if(NOT WIN32)
-	target_link_libraries(openkit-sample pthread)	# TODO Johannes Baeuerle. Check if pthread is necessary
+	target_link_libraries(openkit-sample pthread)
 endif()
 
 string(REPLACE "bin/libcurl.dll" "lib/libcurl_imp.lib" HAXX ${CURL_LIBRARIES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,7 +89,7 @@ endif()
 target_compile_definitions(unittests PRIVATE -DOPENKIT_STATIC_DEFINE)
 
 if(NOT WIN32)
-	target_link_libraries(unittests pthread)	# TODO Johannes Baeuerle. Check if pthread is necessary
+	target_link_libraries(unittests pthread)
 else()
 	add_custom_command(TARGET curltest POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CURL_LIBRARIES} ${CMAKE_SOURCE_DIR}/3rdparty/zlib-1.2.11/bin/zlib.dll ${CMAKE_BINARY_DIR}/bin


### PR DESCRIPTION
for openkit-sample and unittest binaries