### PR TITLE
BEACON_DATA_DELIMITER as null-terminated string

### DIFF
--- a/src/protocol/Beacon.cxx
+++ b/src/protocol/Beacon.cxx
@@ -433,10 +433,11 @@ std::unique_ptr<protocol::StatusResponse> Beacon::send(std::shared_ptr<providers
 	{
 		// prefix for this chunk - must be built up newly, due to changing timestamps
 		core::UTF8String prefix = mBasicBeaconData;
-		prefix.concatenate(core::UTF8String(&BEACON_DATA_DELIMITER));
+		core::UTF8String delimiter = core::UTF8String(BEACON_DATA_DELIMITER);
+		prefix.concatenate(delimiter);
 		prefix.concatenate(createTimestampData());
 
-		core::UTF8String chunk = mBeaconCache->getNextBeaconChunk(mSessionNumber, prefix, mConfiguration->getMaxBeaconSize() - 1024, core::UTF8String(&BEACON_DATA_DELIMITER));
+		core::UTF8String chunk = mBeaconCache->getNextBeaconChunk(mSessionNumber, prefix, mConfiguration->getMaxBeaconSize() - 1024, delimiter);
 		if (chunk == nullptr || chunk.empty())
 		{
 			return response;

--- a/src/protocol/BeaconProtocolConstants.h
+++ b/src/protocol/BeaconProtocolConstants.h
@@ -20,7 +20,7 @@
 namespace protocol
 {
 	//delimiter
-	constexpr char BEACON_DATA_DELIMITER = '&';
+	constexpr char BEACON_DATA_DELIMITER[] = "&";
 
 	//web request tag prefix constant
 	constexpr char TAG_PREFIX[] = "MT";


### PR DESCRIPTION
compilers that do not use padding between the char arrays in
BeaconProtocolConstants generate invalid Beacons by erroneously
copying to much bytes when creating an UTF8String from the address
of the single char value BEACON_DATA_DELIMITER. On gcc this led to
to a string of '&MT' because the TAG_PREFIX string directly follows the
BEACON_DATA_DELIMITER string in memory and there is no terminating
'\0' character in between.

Fix is to have correctly null-terminated strings for all values in
BeaconProtocolConstants