### PR TITLE
Validate URL schemas when tracing web requests

### DIFF
--- a/src/core/Action.cxx
+++ b/src/core/Action.cxx
@@ -157,6 +157,11 @@ std::shared_ptr<openkit::IWebRequestTracer> Action::traceWebRequest(const char* 
 		mLogger->warning("%s traceWebRequest (string): url must not be null or empty", toString().c_str());
 		return NULL_WEB_REQUEST_TRACER;
 	}
+	if (!WebRequestTracerStringURL::isValidURLScheme(urlString))
+	{
+		mLogger->warning("%s traceWebRequest (string): url \"%s\" does not have a valid scheme", toString().c_str(), urlString.getStringData().c_str());
+		return NULL_WEB_REQUEST_TRACER;
+	}
 	if (mLogger->isDebugEnabled())
 	{
 		mLogger->debug("%s traceWebRequest (string) (%s))", toString().c_str(), url);

--- a/src/core/WebRequestTracerStringURL.cxx
+++ b/src/core/WebRequestTracerStringURL.cxx
@@ -20,21 +20,32 @@
 #include "core/RootAction.h"
 #include "core/Action.h"
 
+#include <regex>
+
 namespace core
 {
+	static const std::regex SCHEMA_VALIDATION_PATTERN("^[a-z][a-z0-9+\\-.]*://.+", std::regex::icase | std::regex::optimize);
+
 	WebRequestTracerStringURL::WebRequestTracerStringURL(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<protocol::Beacon> beacon, int32_t parentActionID, const UTF8String& url)
 		: WebRequestTracerBase(logger, beacon, parentActionID)
 	{
-		auto indexOfQuestionMark = url.getIndexOf("?");
+		if (isValidURLScheme(url))
+		{
+			auto indexOfQuestionMark = url.getIndexOf("?");
 
-		if (indexOfQuestionMark != std::string::npos)
-		{
-			WebRequestTracerBase::mURL = url.substring(0, indexOfQuestionMark);
-		}
-		else
-		{
-			WebRequestTracerBase::mURL = url;
+			if (indexOfQuestionMark != std::string::npos)
+			{
+				WebRequestTracerBase::mURL = url.substring(0, indexOfQuestionMark);
+			}
+			else
+			{
+				WebRequestTracerBase::mURL = url;
+			}
 		}
 	}
 
+	bool WebRequestTracerStringURL::isValidURLScheme(const UTF8String& url)
+	{
+		return std::regex_match(url.getStringData(), SCHEMA_VALIDATION_PATTERN);
+	}
 }

--- a/src/core/WebRequestTracerStringURL.h
+++ b/src/core/WebRequestTracerStringURL.h
@@ -40,6 +40,13 @@ namespace core
 		/// @param[in] url url of the web request
 		///
 		WebRequestTracerStringURL(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<protocol::Beacon> beacon, int32_t parentActionID, const UTF8String& url);
+
+		///
+		/// Test if given {@c url} contains a valid URL scheme according to RFC3986.
+		/// @param[in] The url to validate
+		/// @return {@code true} on success, {@code false} otherwhise.
+		///
+		static bool isValidURLScheme(const UTF8String& url);
 	};
 }
 

--- a/test/OpenKitTests.cmake
+++ b/test/OpenKitTests.cmake
@@ -38,6 +38,7 @@ set(OPENKIT_SOURCES_UNITTEST
 	${CMAKE_CURRENT_LIST_DIR}/core/ActionTest.cxx
 	${CMAKE_CURRENT_LIST_DIR}/core/RootActionTest.cxx
 	${CMAKE_CURRENT_LIST_DIR}/core/WebRequestTracerBaseTest.cxx
+	${CMAKE_CURRENT_LIST_DIR}/core/WebRequestTracerStringURLTest.cxx
 	${CMAKE_CURRENT_LIST_DIR}/core/util/CompressorTest.cxx
 	${CMAKE_CURRENT_LIST_DIR}/core/util/URLEncodingTest.cxx
 	${CMAKE_CURRENT_LIST_DIR}/core/util/SynchronizedQueueTest.cxx

--- a/test/core/ActionTest.cxx
+++ b/test/core/ActionTest.cxx
@@ -407,6 +407,21 @@ TEST_F(ActionTest, tracingAnEmptyStringWebRequestIsNotAllowed)
 	ASSERT_TRUE(typeCast != nullptr);
 }
 
+TEST_F(ActionTest, tracingAnInvalidUrlSchemeIsNotAllowed)
+{
+	// create test environment
+	// create action without parent action
+	auto testAction = std::make_shared<core::Action>(logger, mockBeacon, core::UTF8String("test action"));
+
+	// execute the test call
+	auto webRequestTracer = testAction->traceWebRequest("1337://fourtytwo.com");
+
+	// verify the returned request
+	ASSERT_TRUE(webRequestTracer != nullptr);
+	std::shared_ptr<core::NullWebRequestTracer> typeCast = std::dynamic_pointer_cast<core::NullWebRequestTracer>(webRequestTracer);
+	ASSERT_TRUE(typeCast != nullptr);
+}
+
 TEST_F(ActionTest, actionsEnteredAndLeft)
 {
 	session->startSession();

--- a/test/core/WebRequestTracerStringURLTest.cxx
+++ b/test/core/WebRequestTracerStringURLTest.cxx
@@ -1,0 +1,125 @@
+/**
+* Copyright 2018 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <core/WebRequestTracerStringURL.h>
+
+#include "../protocol/MockBeacon.h"
+
+#include <providers/DefaultThreadIDProvider.h>
+#include <providers/DefaultTimingProvider.h>
+#include <protocol/ssl/SSLStrictTrustManager.h>
+#include <providers/DefaultSessionIDProvider.h>
+#include <providers/DefaultHTTPClientProvider.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace core;
+
+static const char* APP_ID = "appID";
+static const char* APP_NAME = "appName";
+static const char* TAG = "THE_TAG";
+
+class WebRequestTracerStringURLTest : public testing::Test
+{
+public:
+
+	virtual void SetUp() override
+	{
+		auto threadIDProvider = std::make_shared<providers::DefaultThreadIDProvider>();
+		auto timingProvider = std::make_shared<providers::DefaultTimingProvider>();
+		auto sessionIDProvider = std::make_shared<providers::DefaultSessionIDProvider>();
+
+		auto trustManager = std::make_shared<protocol::SSLStrictTrustManager>();
+
+		auto  device = std::shared_ptr<configuration::Device>(new configuration::Device(core::UTF8String(""), core::UTF8String(""), core::UTF8String("")));
+
+		auto beaconCacheConfiguration = std::make_shared<configuration::BeaconCacheConfiguration>(-1, -1, -1);
+		auto configuration = std::shared_ptr<configuration::Configuration>(new configuration::Configuration(device, configuration::OpenKitType::Type::DYNATRACE,
+			core::UTF8String(APP_NAME), "", APP_ID, 0, "",
+			sessionIDProvider, trustManager, beaconCacheConfiguration));
+		configuration->enableCapture();
+
+		auto beaconCache = std::make_shared<caching::BeaconCache>(logger);
+
+		logger = std::shared_ptr<openkit::ILogger>(new core::util::DefaultLogger(devNull, true));
+		mockBeacon = std::make_shared<testing::NiceMock<test::MockBeacon>>(logger, beaconCache, configuration, core::UTF8String(""), threadIDProvider, timingProvider);
+	}
+
+	virtual void TearDown() override
+	{
+		logger = nullptr;
+	}
+
+	std::ostringstream devNull;
+	std::shared_ptr<openkit::ILogger> logger;
+	std::shared_ptr<testing::NiceMock<test::MockBeacon>> mockBeacon;
+};
+
+
+TEST_F(WebRequestTracerStringURLTest, emptyStringIsNotAValidURLScheme)
+{
+	// then
+	ASSERT_FALSE(WebRequestTracerStringURL::isValidURLScheme(UTF8String()));
+}
+
+TEST_F(WebRequestTracerStringURLTest, aValidSchemeStartsWithALetter)
+{
+	// when starting with lower case letter, then
+	ASSERT_TRUE(WebRequestTracerStringURL::isValidURLScheme("a://some.host"));
+}
+
+TEST_F(WebRequestTracerStringURLTest, aValidSchemeOnlyContainsLettersDigitsPlusPeriodOrHyphen)
+{
+	// when the url scheme contains all allowed characters, then
+	ASSERT_TRUE(WebRequestTracerStringURL::isValidURLScheme("b1+Z6.-://some.host"));
+}
+
+TEST_F(WebRequestTracerStringURLTest, aValidSchemeAllowsUpperCaseLettersToo)
+{
+	// when the url scheme contains all allowed characters, then
+	ASSERT_TRUE(WebRequestTracerStringURL::isValidURLScheme("Obp1e+nZK6i.t-://some.host"));
+}
+
+TEST_F(WebRequestTracerStringURLTest, aValidSchemeDoesNotStartWithADigit)
+{
+	// then
+	ASSERT_FALSE(WebRequestTracerStringURL::isValidURLScheme("1a://some.host"));
+}
+
+TEST_F(WebRequestTracerStringURLTest, aSchemeIsInvalidIfInvalidCharactersAreEncountered)
+{
+	// then
+	ASSERT_FALSE(WebRequestTracerStringURL::isValidURLScheme("a()[]{}@://some.host"));
+}
+
+TEST_F(WebRequestTracerStringURLTest, anURLIsOnlySetInConstructorIfItIsValid)
+{
+	// given
+	WebRequestTracerStringURL target(logger, mockBeacon, 42L, "a1337://foo");
+
+	// then
+	ASSERT_EQ(target.getURL(), "a1337://foo");
+}
+
+TEST_F(WebRequestTracerStringURLTest, ifURLIsInvalidTheDefaultValueIsUsed)
+{
+	// given
+	WebRequestTracerStringURL target(logger, mockBeacon, 42L, "1337://foo");
+
+	// then
+	ASSERT_EQ(target.getURL(), "<unknown>");
+}


### PR DESCRIPTION
Validate that the scheme of the given String URL to
trace conforms to RFC3986 and that it contains
at least some character after the delimiting ://