### PR TITLE
Re-Write scheme validation pattern

### DIFF
--- a/src/core/WebRequestTracerStringURL.cxx
+++ b/src/core/WebRequestTracerStringURL.cxx
@@ -24,7 +24,7 @@
 
 namespace core
 {
-	static const std::regex SCHEMA_VALIDATION_PATTERN("^[a-z][a-z0-9+\\-.]*://.+", std::regex::icase | std::regex::optimize);
+	static const std::regex SCHEMA_VALIDATION_PATTERN("^[a-zA-Z][a-zA-Z0-9+\\-.]*://.+$", std::regex::optimize | std::regex::ECMAScript);
 
 	WebRequestTracerStringURL::WebRequestTracerStringURL(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<protocol::Beacon> beacon, int32_t parentActionID, const UTF8String& url)
 		: WebRequestTracerBase(logger, beacon, parentActionID)


### PR DESCRIPTION
It seems there is a bug in GCC which only checks
icase for the first letter in range.
(see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71500)