### PR TITLE
avoid the use of std::regex::icase

### DIFF
--- a/src/core/util/InetAddressValidator.cxx
+++ b/src/core/util/InetAddressValidator.cxx
@@ -71,12 +71,12 @@ bool InetAddressValidator::IsIPv6HexCompressedAddress(const core::UTF8String& ip
 static const std::regex ipv6MixedStdOrCompressedRegex(
 	"^"																// Anchor address
 	"(?:"
-	"(?:[A-Fa-f0-9]{1,4}:){6}"											// Non-compressed
-	"|(?=(?:[A-Fa-f0-9]{0,4}:){2,6}"									// Compressed with 2 to 6 colons
+	"(?:[0-9A-Fa-f]{1,4}:){6}"											// Non-compressed
+	"|(?=(?:[0-9A-Fa-f]{0,4}:){2,6}"									// Compressed with 2 to 6 colons
 	R"((?:[0-9]{1,3}\.){3}[0-9]{1,3})"								// and 4 bytes
 	R"((?![:.\w])))"												//  and anchored
 	"(([0-9A-Fa-f]{1,4}:){1,5}|:)((:[0-9A-Fa-f]{1,4}){1,5}:|:)"			//  and at most 1 double colon
-	"|::(?:[A-Fa-f0-9]{1,4}:){5}"										// Compressed with 7 colons and 5 numbers
+	"|::(?:[0-9A-Fa-f]{1,4}:){5}"										// Compressed with 7 colons and 5 numbers
 	")"
 	R"((?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3})"	// 255.255.255.
 	"(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])"				// 255


### PR DESCRIPTION
regexes use A-Fa-f0-9 without icase instead of A-F0-9 with icase
removed all occurences of icase