### PR TITLE
HTTPClient does not return nullptr in public API

### DIFF
--- a/src/protocol/Beacon.cxx
+++ b/src/protocol/Beacon.cxx
@@ -178,20 +178,17 @@ void Beacon::addKeyValuePair(core::UTF8String& s, const core::UTF8String& key, c
 
 void Beacon::addKeyValuePair(core::UTF8String& s, const core::UTF8String& key, int32_t value)
 {
-	appendKey(s, key);
-	s.concatenate(std::to_string(value));
+	addKeyValuePair(s, key, std::to_string(value));
 }
 
 void Beacon::addKeyValuePair(core::UTF8String& s, const core::UTF8String& key, int64_t value)
 {
-	appendKey(s, key);
-	s.concatenate(std::to_string(value));
+	addKeyValuePair(s, key, std::to_string(value));
 }
 
 void Beacon::addKeyValuePair(core::UTF8String& s, const core::UTF8String& key, double value)
 {
-	appendKey(s, key);
-	s.concatenate(std::to_string(value));
+	addKeyValuePair(s, key, std::to_string(value));
 }
 
 int32_t Beacon::createSequenceNumber()

--- a/src/protocol/HTTPClient.h
+++ b/src/protocol/HTTPClient.h
@@ -110,21 +110,31 @@ namespace protocol
 		/// @param[in] method the HTTP method to use. Currently either POST or GET
 		/// @returns a status response with the response data for the request or @c nullptr on error
 		///
-		std::unique_ptr<Response> sendRequestInternal(const RequestType requestType, const core::UTF8String& url, const core::UTF8String& clientIPAddress, const core::UTF8String& beaconData, const HttpMethod method);
+		std::unique_ptr<Response> sendRequestInternal(RequestType requestType, const core::UTF8String& url, const core::UTF8String& clientIPAddress, const core::UTF8String& beaconData, const HttpMethod method);
 
-		void buildMonitorURL(core::UTF8String& monitorURL, const core::UTF8String& baseURL, const core::UTF8String& applicationID, uint32_t serverID);
+		///
+		/// Build URL used for status check and beacon send requests
+		/// @param[in,out] monitorURL the url to build
+		/// @param[in] baseURL the beacon base url without the query string
+		/// @param[in] applicationID
+		/// @param[in] serverID
+		///
+		static void buildMonitorURL(core::UTF8String& monitorURL, const core::UTF8String& baseURL, const core::UTF8String& applicationID, uint32_t serverID);
 
-		void buildTimeSyncURL(core::UTF8String& monitorURL, const core::UTF8String& baseURL);
+		static void buildTimeSyncURL(core::UTF8String& timeSyncURL, const core::UTF8String& baseURL);
 
-		void buildNewSessionURL(core::UTF8String& monitorURL, const core::UTF8String& baseURL, const core::UTF8String& applicationID, uint32_t serverID);
+		static void buildNewSessionURL(core::UTF8String& newSessionURL, const core::UTF8String& baseURL, const core::UTF8String& applicationID, uint32_t serverID);
 
-		void appendQueryParam(core::UTF8String& url, const char* key, const char* vaalue);
+		static void appendQueryParam(core::UTF8String& url, const char* key, const char* vaalue);
 
-		std::unique_ptr<Response> handleResponse(int32_t httpCode, const std::string& buffer, const Response::ResponseHeaders& responseHeaders);
+		std::unique_ptr<Response> handleResponse(RequestType requestType, int32_t httpCode, const std::string& buffer, const Response::ResponseHeaders& responseHeaders);
 
 		static size_t readFunction(void *ptr, size_t elementSize, size_t numberOfElements, void* userPtr);
 
+		static std::unique_ptr<Response> unknownErrorResponse(RequestType requestType);
+
 	private:
+
 		/// Logger to write traces to
 		std::shared_ptr<openkit::ILogger> mLogger;
 

--- a/src/protocol/Response.cxx
+++ b/src/protocol/Response.cxx
@@ -18,10 +18,17 @@
 
 using namespace protocol;
 
+static constexpr int32_t HTTP_BAD_REQUEST = 400;
+
 Response::Response(int32_t responseCode, const ResponseHeaders& responseHeaders)
 	: mResponseCode(responseCode)
 	, mResponseHeaders(responseHeaders)
 {
+}
+
+bool Response::isErroneousResponse() const
+{
+	return getResponseCode() >= HTTP_BAD_REQUEST;
 }
 
 int32_t Response::getResponseCode() const

--- a/src/protocol/Response.h
+++ b/src/protocol/Response.h
@@ -37,7 +37,7 @@ namespace protocol
 		///
 		/// Construct a response given a response code
 		/// @param[in] responseCode a numerical code for the status of a request
-		/// @param[in[ responseHeaders a map of key-value pairs containing the response headers and values.
+		/// @param[in] responseHeaders a map of key-value pairs containing the response headers and values.
 		///
 		Response(int32_t responseCode, const ResponseHeaders& responseHeaders);
 
@@ -45,6 +45,13 @@ namespace protocol
 		/// Destructor
 		///
 		virtual ~Response() {}
+
+		///
+		/// Return a boolean indicating whether this is an erroneous response or not.
+		/// @remarks A response is considered to be erroneous, if the getResponseCode() returns >= 400.
+		/// @return @c true if this response is erroneous, @c false otherwise.
+		///
+		bool isErroneousResponse() const;
 
 		///
 		/// Return the response code

--- a/test/protocol/StatusResponseTest.cxx
+++ b/test/protocol/StatusResponseTest.cxx
@@ -593,6 +593,42 @@ TEST_F(StatusResponseTest, notExistingKey)
 	EXPECT_TRUE(statusResponse.isCaptureCrashes());
 }
 
+TEST_F(StatusResponseTest, responseCodeIsSet)
+{
+	// given
+	auto target = StatusResponse(UTF8String(), 418, Response::ResponseHeaders());
+
+	// then
+	ASSERT_EQ(418, target.getResponseCode());
+}
+
+TEST_F(StatusResponseTest, isErroneousResponseGivesTrueForErrorCodeEqualTo400)
+{
+	// given
+	auto target = StatusResponse(UTF8String(), 400, Response::ResponseHeaders());
+
+	// then
+	ASSERT_TRUE(target.isErroneousResponse());
+}
+
+TEST_F(StatusResponseTest, isErroneousResponseGivesTrueForErrorCodeGreaterThan400)
+{
+	// given
+	auto target = StatusResponse(UTF8String(), 401, Response::ResponseHeaders());
+
+	// then
+	ASSERT_TRUE(target.isErroneousResponse());
+}
+
+TEST_F(StatusResponseTest, isErroneousResponseGivesFalseForErrorCodeLessThan400)
+{
+	// given
+	auto target = StatusResponse(UTF8String(), 399, Response::ResponseHeaders());
+
+	// then
+	ASSERT_FALSE(target.isErroneousResponse());
+}
+
 TEST_F(StatusResponseTest, headersAreSet)
 {
 	// given

--- a/test/protocol/TimeSyncResponseTest.cxx
+++ b/test/protocol/TimeSyncResponseTest.cxx
@@ -168,6 +168,42 @@ TEST_F(TimeSyncResponseTest, notExistingKey)
 	EXPECT_EQ(-1, timeSyncResponse.getResponseSendTime());
 }
 
+TEST_F(TimeSyncResponseTest, responseCodeIsSet)
+{
+	// given
+	auto target = TimeSyncResponse(UTF8String(), 418, Response::ResponseHeaders());
+
+	// then
+	ASSERT_EQ(418, target.getResponseCode());
+}
+
+TEST_F(TimeSyncResponseTest, isErroneousResponseGivesTrueForErrorCodeEqualTo400)
+{
+	// given
+	auto target = TimeSyncResponse(UTF8String(), 400, Response::ResponseHeaders());
+
+	// then
+	ASSERT_TRUE(target.isErroneousResponse());
+}
+
+TEST_F(TimeSyncResponseTest, isErroneousResponseGivesTrueForErrorCodeGreaterThan400)
+{
+	// given
+	auto target = TimeSyncResponse(UTF8String(), 401, Response::ResponseHeaders());
+
+	// then
+	ASSERT_TRUE(target.isErroneousResponse());
+}
+
+TEST_F(TimeSyncResponseTest, isErroneousResponseGivesFalseForErrorCodeLessThan400)
+{
+	// given
+	auto target = TimeSyncResponse(UTF8String(), 399, Response::ResponseHeaders());
+
+	// then
+	ASSERT_FALSE(target.isErroneousResponse());
+}
+
 TEST_F(TimeSyncResponseTest, headersAreSet)
 {
 	// given


### PR DESCRIPTION
nullptr response return shall be avoided as much as possible
and also erroneous responses are returned