### PR TITLE
Introduce new function for deviceID of type const char*

### DIFF
--- a/include/api-c/OpenKit-c.h
+++ b/include/api-c/OpenKit-c.h
@@ -130,6 +130,16 @@ extern "C" {
 	OPENKIT_EXPORT struct OpenKitConfigurationHandle* createOpenKitConfiguration(const char* endpointURL, const char* applicationID, int64_t deviceID);
 
 	///
+	/// Creates an OpenKit configuration object with @c deviceID given as string.
+	/// @remarks If the given @c deviceID is longer than 250 characters, only the first 250 characters are used.
+	/// @param[in] endpointURL endpoint OpenKit connects to
+	/// @param[in] applicationID unique application id
+	/// @param[in] deviceID unique device id
+	/// @returns a configuration object that can be used for both AppMon and Dynatrace OpenKit instances
+	///
+	OPENKIT_EXPORT struct OpenKitConfigurationHandle* createOpenKitConfigurationWithStringDeviceID(const char* endpointURL, const char* applicationID, const char* deviceID);
+
+	///
 	/// Destroys a given configuration
 	/// @param[in] configurationHandle configuration handle to clean up
 	///

--- a/src/api-c/OpenKit-c.cxx
+++ b/src/api-c/OpenKit-c.cxx
@@ -222,7 +222,7 @@ extern "C" {
 	{
 		char* endpointURL = nullptr;
 		char* applicationID = nullptr;
-		int64_t deviceID = -1;
+		char* deviceID = nullptr;
 		char* applicationName = nullptr;
 		LoggerHandle* loggerHandle = nullptr;
 		bool ownsLoggerHandle = false;
@@ -242,6 +242,11 @@ extern "C" {
 
 	struct OpenKitConfigurationHandle* createOpenKitConfiguration(const char* endpointURL, const char* applicationID, int64_t deviceID)
 	{
+		return createOpenKitConfigurationWithStringDeviceID(endpointURL, applicationID, std::to_string(deviceID).c_str());
+	}
+
+	struct OpenKitConfigurationHandle* createOpenKitConfigurationWithStringDeviceID(const char* endpointURL, const char* applicationID, const char* deviceID)
+	{
 		OpenKitConfigurationHandle* handle = nullptr;
 		try
 		{
@@ -251,14 +256,13 @@ extern "C" {
 			{
 				handle->endpointURL = duplicateString(endpointURL);
 				handle->applicationID = duplicateString(applicationID);
-				handle->deviceID = deviceID;
+				handle->deviceID = duplicateString(deviceID);
 			}
 		}
 		CATCH_AND_IGNORE_ALL()
 
 		return handle;
 	}
-
 
 
 	void destroyOpenKitConfiguration(struct OpenKitConfigurationHandle* configurationHandle)


### PR DESCRIPTION
In C++ an appropriate overload has been created.
Since the concept of overloads is not existing in C
a new function with different name has been added to achieve the same
goal.