### PR TITLE
Fix missing includes for older GCC

### DIFF
--- a/include/OpenKit/AbstractOpenKitBuilder.h
+++ b/include/OpenKit/AbstractOpenKitBuilder.h
@@ -23,6 +23,7 @@
 #include "OpenKit/DataCollectionLevel.h"
 #include "OpenKit/CrashReportingLevel.h"
 
+#include <cstdint>
 #include <memory>
 
 #ifndef DOXYGEN_HIDE_FROM_DOC

--- a/include/OpenKit/AppMonOpenKitBuilder.h
+++ b/include/OpenKit/AppMonOpenKitBuilder.h
@@ -19,6 +19,8 @@
 
 #include "OpenKit/AbstractOpenKitBuilder.h"
 
+#include <cstdint>
+
 namespace openkit
 {
 	///

--- a/include/OpenKit/CrashReportingLevel.h
+++ b/include/OpenKit/CrashReportingLevel.h
@@ -17,7 +17,7 @@
 #ifndef _OPENKIT_CRASHREPORTINGLEVEL_H
 #define _OPENKIT_CRASHREPORTINGLEVEL_H
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace openkit
 {

--- a/include/OpenKit/DataCollectionLevel.h
+++ b/include/OpenKit/DataCollectionLevel.h
@@ -17,7 +17,7 @@
 #ifndef _OPENKIT_DATACOLLECTIONLEVEL_H
 #define _OPENKIT_DATACOLLECTIONLEVEL_H
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace openkit
 {

--- a/include/OpenKit/DynatraceOpenKitBuilder.h
+++ b/include/OpenKit/DynatraceOpenKitBuilder.h
@@ -19,6 +19,8 @@
 
 #include "OpenKit/AbstractOpenKitBuilder.h"
 
+#include <cstdint>
+
 namespace openkit
 {
 	///

--- a/include/OpenKit/IAction.h
+++ b/include/OpenKit/IAction.h
@@ -19,7 +19,7 @@
 
 #include "OpenKit_export.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 
 namespace openkit

--- a/include/OpenKit/IOpenKit.h
+++ b/include/OpenKit/IOpenKit.h
@@ -19,6 +19,7 @@
 
 #include "OpenKit_export.h"
 
+#include <cstdint>
 #include <memory>
 
 namespace openkit

--- a/include/OpenKit/IRootAction.h
+++ b/include/OpenKit/IRootAction.h
@@ -19,7 +19,7 @@
 
 #include "OpenKit_export.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 
 namespace openkit

--- a/include/OpenKit/IWebRequestTracer.h
+++ b/include/OpenKit/IWebRequestTracer.h
@@ -19,7 +19,7 @@
 
 #include "OpenKit_export.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 
 namespace openkit


### PR DESCRIPTION
It seems that GCC - to be specific g++ - version 4.7
does not compile OpenKit, because of unknown type `int64_t`.
This can be fixed by including `<stdint.h>` or `<cstdint>`.
I prefer the latter, since this is the C++ header.