### PR TITLE
Ensure that interruptible sleeps in state engine

### DIFF
--- a/src/communication/BeaconSendingCaptureOffState.cxx
+++ b/src/communication/BeaconSendingCaptureOffState.cxx
@@ -63,6 +63,11 @@ void BeaconSendingCaptureOffState::doExecute(BeaconSendingContext& context)
 	if (delta > 0 && !context.isShutdownRequested())
 	{
 		context.sleep(delta);
+		if (context.isShutdownRequested())
+		{
+			// shutdown was requested while sleeping - do not send any status request
+			return;
+		}
 	}
 	auto statusResponse = BeaconSendingRequestUtil::sendStatusRequest(context, STATUS_REQUEST_RETRIES, INITIAL_RETRY_SLEEP_TIME_MILLISECONDS.count());
 	handleStatusResponse(context, statusResponse);

--- a/src/communication/BeaconSendingCaptureOnState.cxx
+++ b/src/communication/BeaconSendingCaptureOnState.cxx
@@ -48,6 +48,12 @@ void BeaconSendingCaptureOnState::doExecute(BeaconSendingContext& context)
 	}
 
 	context.sleep();
+	if (context.isShutdownRequested())
+	{
+		// shutdown was requested during sleep
+		// return and let the base class handle this
+		return;
+	}
 
 	// sned new session request for all sessions that are new
 	auto newSessionsResponse = sendNewSessionRequests(context);

--- a/src/communication/BeaconSendingContext.h
+++ b/src/communication/BeaconSendingContext.h
@@ -30,6 +30,8 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
+#include <condition_variable>
 #include <chrono>
 
 namespace communication
@@ -328,8 +330,14 @@ namespace communication
 		/// instance of AbstractBeaconSendingState with the following state
 		std::shared_ptr<AbstractBeaconSendingState> mNextState;
 
-		/// Atomic shutdown flag
-		std::atomic<bool> mShutdown;
+		/// Boolean indicating shutdown flag.
+		bool mShutdown;
+
+		/// mutex used for sychronisation access to mShutdown
+		mutable std::mutex mShutdownMutex;
+
+		/// condition variable used to wait on when calling sleep.
+		std::condition_variable mSleepConditionVariable;
 
 		/// Atomic flag for successful initialization
 		std::atomic<bool> mInitSucceeded;

--- a/src/communication/BeaconSendingRequestUtil.cxx
+++ b/src/communication/BeaconSendingRequestUtil.cxx
@@ -26,7 +26,7 @@ std::shared_ptr<StatusResponse> BeaconSendingRequestUtil::sendStatusRequest(Beac
 	uint64_t sleepTimeInMillis = initialRetryDelayInMillis;
 	uint32_t retry = 0;
 
-	while (true) 
+	while (!context.isShutdownRequested()) 
 	{
 		std::shared_ptr<IHTTPClient> httpClient = context.getHTTPClient();
 		if (httpClient == nullptr)
@@ -37,14 +37,14 @@ std::shared_ptr<StatusResponse> BeaconSendingRequestUtil::sendStatusRequest(Beac
 		statusResponse = httpClient->sendStatusRequest();
 		if (BeaconSendingResponseUtil::isSuccessfulResponse(statusResponse)
 			|| BeaconSendingResponseUtil::isTooManyRequestsResponse(statusResponse) // is handled by the states
-			|| retry >= numRetries
-			|| context.isShutdownRequested())
+			|| retry >= numRetries)
 		{
 			break;
 		}
 
 		// if no (valid) status response was received -> sleep and double the delay for each retry
 		context.sleep(sleepTimeInMillis);
+
 		sleepTimeInMillis *= 2;
 		retry++;
 	}

--- a/test/communication/BeaconSendingContextTest.cxx
+++ b/test/communication/BeaconSendingContextTest.cxx
@@ -404,10 +404,15 @@ TEST_F(BeaconSendingContextTest, sleepDefaultTime)
 
 	// then
 	EXPECT_CALL(*timingProvider, sleep(BeaconSendingContext::DEFAULT_SLEEP_TIME_MILLISECONDS.count()))
-		.Times(testing::Exactly(1));
+		.Times(testing::Exactly(0));
 
 	// when
+	auto start = std::chrono::system_clock::now();
 	target->sleep();
+	auto duration = std::chrono::system_clock::now() - start;
+
+	// then ensure sleep is correct
+	ASSERT_GE(duration, BeaconSendingContext::DEFAULT_SLEEP_TIME_MILLISECONDS);
 }
 
 TEST_F(BeaconSendingContextTest, sleepWithGivenTime)
@@ -420,10 +425,15 @@ TEST_F(BeaconSendingContextTest, sleepWithGivenTime)
 
 	// then
 	EXPECT_CALL(*timingProvider, sleep(1234L))
-		.Times(testing::Exactly(1));
+		.Times(testing::Exactly(0));
 
 	// when
-	target->sleep(1234L);
+	auto start = std::chrono::system_clock::now();
+	target->sleep(100L);
+	auto duration = std::chrono::system_clock::now() - start;
+
+	// then ensure sleep is correct
+	ASSERT_GE(duration, std::chrono::milliseconds(100L));
 }
 
 TEST_F(BeaconSendingContextTest, defaultLastTimeSyncTimeIsMinusOne)

--- a/test/communication/BeaconSendingRequestUtilTest.cxx
+++ b/test/communication/BeaconSendingRequestUtilTest.cxx
@@ -55,12 +55,11 @@ TEST_F(BeaconSendingRequestUtilTest, sendStatusRequestIsAbortedWhenShutdownIsReq
 	// given
 	ON_CALL(*mMockHTTPClient, sendStatusRequestRawPtrProxy())
 		.WillByDefault(testing::Invoke([&]() ->  protocol::StatusResponse* { return new protocol::StatusResponse(mLogger, "", 400, protocol::Response::ResponseHeaders()); }));
-	ON_CALL(*mMockContext, isShutdownRequested())
-		.WillByDefault(testing::Return(true));
 
 	// verify
 	EXPECT_CALL(*mMockContext, isShutdownRequested())
-		.Times(::testing::Exactly(1));
+		.WillOnce(::testing::Return(false))
+		.WillRepeatedly(::testing::Return(true));
 	EXPECT_CALL(*mMockContext, getHTTPClient())
 		.Times(::testing::Exactly(1));
 	EXPECT_CALL(*mMockHTTPClient, sendStatusRequestRawPtrProxy())


### PR DESCRIPTION
When executing states, all calls to sleep must be
interruptible.
Reason: If an OpenKit user shuts down while
OpenKit is in CaptureOff state, this must not block
until OpenKit wakes up.

Implementation detail: This is done using timed wait
on a condition variable.
Some conditions have been changed (especially loop conditions),
therefore tests were also adjusted.