### PR TITLE
URL encode deviceID and appID

### DIFF
--- a/src/configuration/Configuration.cxx
+++ b/src/configuration/Configuration.cxx
@@ -16,6 +16,7 @@
 
 #include "configuration/Configuration.h"
 #include "configuration/HTTPClientConfiguration.h"
+#include "core/util/URLEncoding.h"
 
 
 using namespace configuration;
@@ -39,6 +40,7 @@ Configuration::Configuration(std::shared_ptr<configuration::Device> device, Open
 	, mOpenKitType(openKitType)
 	, mApplicationName(applicationName)
 	, mApplicationID(applicationID)
+	, mApplicationIDPercentEncoded(core::util::URLEncoding::urlencode(applicationID, { '_' } ))
 	, mApplicationVersion(applicationVersion)
 	, mEndpointURL(endpointURL)
 	, mDeviceID(deviceID)
@@ -152,6 +154,11 @@ const core::UTF8String& Configuration::getApplicationName() const
 const core::UTF8String& Configuration::getApplicationID() const
 {
 	return mApplicationID;
+}
+
+const core::UTF8String& Configuration::getApplicationIDPercentEncoded() const
+{
+	return mApplicationIDPercentEncoded;
 }
 
 const core::UTF8String& Configuration::getApplicationVersion() const

--- a/src/configuration/Configuration.h
+++ b/src/configuration/Configuration.h
@@ -109,6 +109,12 @@ namespace configuration
 		const core::UTF8String& getApplicationID() const;
 
 		///
+		/// Returns the percent-encoded application id
+		/// @returns the application id
+		///
+		const core::UTF8String& getApplicationIDPercentEncoded() const;
+
+		///
 		/// Returns the application version
 		/// @returns the application version
 		///
@@ -205,6 +211,9 @@ namespace configuration
 
 		/// application id
 		core::UTF8String mApplicationID;
+
+		/// percent encoded id
+		core::UTF8String mApplicationIDPercentEncoded;
 
 		/// the application version
 		core::UTF8String mApplicationVersion;

--- a/src/core/util/URLEncoding.h
+++ b/src/core/util/URLEncoding.h
@@ -39,6 +39,17 @@ namespace core
 			static core::UTF8String urlencode(const core::UTF8String& string);
 
 			///
+			/// URL-Encode the given string, taking additional characters into account
+			/// which are treated as reserved characters.
+			///
+			/// @param string The string to encode.
+			/// @param additionalReservedCharacters Additional characters to consider as reserved.
+			/// @returns url-encoded version of the current string
+			///
+			static core::UTF8String urlencode(const core::UTF8String& string,
+											  const std::unordered_set<char>& additionalReservedCharacters);
+
+			///
 			/// URL-Decode the given string
 			/// @returns url-decoded version of the current string
 			///

--- a/src/protocol/Beacon.cxx
+++ b/src/protocol/Beacon.cxx
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 
+#include "Beacon.h"
 #include "OpenKit/DataCollectionLevel.h"
 #include "OpenKit/CrashReportingLevel.h"
-#include "Beacon.h"
 #include "ProtocolConstants.h"
 #include "BeaconProtocolConstants.h"
 #include "core/util/URLEncoding.h"
@@ -47,7 +47,7 @@ Beacon::Beacon(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<caching
 	, mBeaconCache(beaconCache)
 	, mHTTPClientConfiguration(configuration->getHTTPClientConfiguration())
 	, mBeaconConfiguration(configuration->getBeaconConfiguration())
-	, mDeviceID(0)
+	, mDeviceID(nullptr)
 	, mRandomGenerator(randomGenerator)
 {
 	if (core::util::InetAddressValidator::IsValidIP(clientIPAddress))
@@ -173,7 +173,7 @@ void Beacon::appendKey(core::UTF8String& s, const core::UTF8String& key)
 void Beacon::addKeyValuePair(core::UTF8String& s, const core::UTF8String& key, const core::UTF8String& value)
 {
 	appendKey(s, key);
-	s.concatenate(core::util::URLEncoding::urlencode(value));
+	s.concatenate(core::util::URLEncoding::urlencode(value, { '_' }));
 }
 
 void Beacon::addKeyValuePair(core::UTF8String& s, const core::UTF8String& key, int32_t value)
@@ -220,11 +220,11 @@ core::UTF8String Beacon::createTag(int32_t parentActionID, int32_t sequenceNumbe
 	webRequestTag.concatenate("_");
 	webRequestTag.concatenate(std::to_string(mHTTPClientConfiguration->getServerID()));
 	webRequestTag.concatenate("_");
-	webRequestTag.concatenate(getDeviceID());
+	webRequestTag.concatenate(core::util::URLEncoding::urlencode(getDeviceID(), { '_' }));
 	webRequestTag.concatenate("_");
 	webRequestTag.concatenate(std::to_string(mSessionNumber));
 	webRequestTag.concatenate("_");
-	webRequestTag.concatenate(mConfiguration->getApplicationID());
+	webRequestTag.concatenate(mConfiguration->getApplicationIDPercentEncoded());
 	webRequestTag.concatenate("_");
 	webRequestTag.concatenate(std::to_string(parentActionID));
 	webRequestTag.concatenate("_");

--- a/src/protocol/Beacon.cxx
+++ b/src/protocol/Beacon.cxx
@@ -47,7 +47,7 @@ Beacon::Beacon(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<caching
 	, mBeaconCache(beaconCache)
 	, mHTTPClientConfiguration(configuration->getHTTPClientConfiguration())
 	, mBeaconConfiguration(configuration->getBeaconConfiguration())
-	, mDeviceID(nullptr)
+	, mDeviceID("")
 	, mRandomGenerator(randomGenerator)
 {
 	if (core::util::InetAddressValidator::IsValidIP(clientIPAddress))

--- a/src/protocol/Beacon.h
+++ b/src/protocol/Beacon.h
@@ -416,6 +416,9 @@ namespace protocol
 		/// device id
 		core::UTF8String mDeviceID;
 
+		/// device id
+		core::UTF8String mDeviceIDPercentEncoded;
+
 		///random generator
 		std::shared_ptr<providers::IPRNGenerator> mRandomGenerator;
 	};

--- a/src/protocol/HTTPClient.cxx
+++ b/src/protocol/HTTPClient.cxx
@@ -367,8 +367,8 @@ void HTTPClient::buildMonitorURL(core::UTF8String& monitorURL, const core::UTF8S
 	monitorURL.concatenate("?");
 	monitorURL.concatenate(REQUEST_TYPE_MOBILE);
 
-	appendQueryParam(monitorURL, QUERY_KEY_SERVER_ID, std::to_string(serverID).c_str());
-	appendQueryParam(monitorURL, QUERY_KEY_APPLICATION, applicationID.getStringData().c_str());
+	appendQueryParam(monitorURL, QUERY_KEY_SERVER_ID, std::to_string(serverID));
+	appendQueryParam(monitorURL, QUERY_KEY_APPLICATION, applicationID);
 	appendQueryParam(monitorURL, QUERY_KEY_VERSION, OPENKIT_VERSION);
 	appendQueryParam(monitorURL, QUERY_KEY_PLATFORM_TYPE, PLATFORM_TYPE_OPENKIT);
 	appendQueryParam(monitorURL, QUERY_KEY_AGENT_TECHNOLOGY_TYPE, AGENT_TECHNOLOGY_TYPE);
@@ -388,13 +388,13 @@ void HTTPClient::buildNewSessionURL(core::UTF8String& newSessionURL, const core:
 }
 
 
-void HTTPClient::appendQueryParam(core::UTF8String& url, const char* key, const char* value)
+void HTTPClient::appendQueryParam(core::UTF8String& url, const char* key, const core::UTF8String& value)
 {
 	// converts the given value string to a URL encoded string
 	url.concatenate("&");
-	url.concatenate(core::util::URLEncoding::urlencode(key));
+	url.concatenate(core::util::URLEncoding::urlencode(key, { '_' }));
 	url.concatenate("=");
-	url.concatenate(core::util::URLEncoding::urlencode(value));
+	url.concatenate(core::util::URLEncoding::urlencode(value, { '_' }));
 }
 
 std::shared_ptr<Response> HTTPClient::unknownErrorResponse(RequestType requestType)

--- a/src/protocol/HTTPClient.h
+++ b/src/protocol/HTTPClient.h
@@ -125,7 +125,7 @@ namespace protocol
 
 		static void buildNewSessionURL(core::UTF8String& newSessionURL, const core::UTF8String& baseURL, const core::UTF8String& applicationID, uint32_t serverID);
 
-		static void appendQueryParam(core::UTF8String& url, const char* key, const char* vaalue);
+		static void appendQueryParam(core::UTF8String& url, const char* key, const core::UTF8String& value);
 
 		std::shared_ptr<Response> handleResponse(RequestType requestType, int32_t httpCode, const std::string& buffer, const Response::ResponseHeaders& responseHeaders);
 

--- a/test/configuration/ConfigurationTest.cxx
+++ b/test/configuration/ConfigurationTest.cxx
@@ -40,12 +40,12 @@ public:
 
 	std::unique_ptr<configuration::Configuration> getDefaultConfiguration()
 	{
-		return std::unique_ptr<Configuration>(new Configuration(device, openKitType, "", "", "", 0, "", sessionIDProvider, sslTrustManager, beaconCacheConfiguration, beaconConfiguration));
+		return std::unique_ptr<Configuration>(new Configuration(device, openKitType, "", "", "/App_ID%", 0, "", sessionIDProvider, sslTrustManager, beaconCacheConfiguration, beaconConfiguration));
 	}
 
 	std::unique_ptr<configuration::Configuration> getConfiguration(const core::UTF8String& beaconURL)
 	{
-		return std::unique_ptr<Configuration>(new Configuration(device, openKitType, "", "", "", 0, beaconURL, sessionIDProvider, sslTrustManager, beaconCacheConfiguration, beaconConfiguration));
+		return std::unique_ptr<Configuration>(new Configuration(device, openKitType, "", "", "/App_ID%", 0, beaconURL, sessionIDProvider, sslTrustManager, beaconCacheConfiguration, beaconConfiguration));
 	}
 private:
 	std::shared_ptr<Device> device = nullptr;
@@ -154,4 +154,22 @@ TEST_F(ConfigurationTest, defaultCrashReportingLevelIsDefaultValueFromBeaconConf
 {
 	auto target = getDefaultConfiguration();
 	ASSERT_EQ(target->getBeaconConfiguration()->getCrashReportingLevel(), configuration::BeaconConfiguration::DEFAULT_CRASH_REPORTING_LEVEL);
+}
+
+TEST_F(ConfigurationTest, getApplicationID)
+{
+	// given
+	auto target = getDefaultConfiguration();
+
+	// then
+	ASSERT_EQ(target->getApplicationID(), "/App_ID%");
+}
+
+TEST_F(ConfigurationTest, getApplicationIDPercentEncodedDoesPropperEncoding)
+{
+	// given
+	auto target = getDefaultConfiguration();
+
+	// then
+	ASSERT_EQ(target->getApplicationIDPercentEncoded(), "%2FApp%5FID%25");
 }

--- a/test/core/util/URLEncodingTest.cxx
+++ b/test/core/util/URLEncodingTest.cxx
@@ -34,7 +34,7 @@ TEST_F(URLEncodingTest, urlEncodeQueryParameterWithSpacesAndEqualsSign)
 	UTF8String expectation("q%3Dgreater%20than%205");
 
 	UTF8String encoded = core::util::URLEncoding::urlencode(s);
-	EXPECT_TRUE(encoded.equals(expectation));
+	ASSERT_TRUE(encoded.equals(expectation));
 }
 
 TEST_F(URLEncodingTest, urlEncodeQueryParameterWithSpacesAndEqualsSignFinallyDecodeAgain)
@@ -43,7 +43,7 @@ TEST_F(URLEncodingTest, urlEncodeQueryParameterWithSpacesAndEqualsSignFinallyDec
 	UTF8String encoded = core::util::URLEncoding::urlencode(s);
 	UTF8String decoded = core::util::URLEncoding::urldecode(encoded);
 
-	EXPECT_TRUE(decoded.equals(s));
+	ASSERT_TRUE(decoded.equals(s));
 }
 
 TEST_F(URLEncodingTest, urlEncodeStringNotChangedAllCharactersAllowed)
@@ -51,7 +51,7 @@ TEST_F(URLEncodingTest, urlEncodeStringNotChangedAllCharactersAllowed)
 	UTF8String s(".All-this~characters_are_Allowed.");
 
 	UTF8String encoded = core::util::URLEncoding::urlencode(s);
-	EXPECT_TRUE(encoded.equals(s));
+	ASSERT_TRUE(encoded.equals(s));
 }
 
 TEST_F(URLEncodingTest, urlEncodeUTF8MultibyteName)
@@ -60,7 +60,7 @@ TEST_F(URLEncodingTest, urlEncodeUTF8MultibyteName)
 	UTF8String expectation("%D7%AA%F0%9F%98%8B");
 
 	UTF8String encoded = core::util::URLEncoding::urlencode(s);
-	EXPECT_TRUE(encoded.equals(expectation));
+	ASSERT_TRUE(encoded.equals(expectation));
 }
 
 TEST_F(URLEncodingTest, urlEncodeUTF8MultibyteNameFinallyDecodeAgain)
@@ -68,7 +68,7 @@ TEST_F(URLEncodingTest, urlEncodeUTF8MultibyteNameFinallyDecodeAgain)
 	UTF8String s("\xD7\xAA\xf0\x9f\x98\x8b");
 	UTF8String encoded = core::util::URLEncoding::urlencode(s);
 	UTF8String decoded = core::util::URLEncoding::urldecode(encoded);
-	EXPECT_TRUE(decoded.equals(s));
+	ASSERT_TRUE(decoded.equals(s));
 }
 
 TEST_F(URLEncodingTest, urlDecodeFailing_PercentFollowedByNonHexCharacterTwoInvalidBytes)
@@ -77,7 +77,7 @@ TEST_F(URLEncodingTest, urlDecodeFailing_PercentFollowedByNonHexCharacterTwoInva
 	UTF8String decoded = core::util::URLEncoding::urldecode(s);
 
 	UTF8String expectation("invalid?string");
-	EXPECT_TRUE(decoded.equals(expectation));
+	ASSERT_TRUE(decoded.equals(expectation));
 }
 
 TEST_F(URLEncodingTest, urlDecodeFailing_PercentFollowedByNonHexCharacterSecondByteInvalid)
@@ -86,7 +86,7 @@ TEST_F(URLEncodingTest, urlDecodeFailing_PercentFollowedByNonHexCharacterSecondB
 	UTF8String decoded = core::util::URLEncoding::urldecode(s);
 
 	UTF8String expectation("invalid?ARstring");
-	EXPECT_TRUE(decoded.equals(expectation));
+	ASSERT_TRUE(decoded.equals(expectation));
 }
 
 TEST_F(URLEncodingTest, urlDecodeFailing_PercentFollowedByNonHexCharacterFirstByteInvalid)
@@ -95,7 +95,7 @@ TEST_F(URLEncodingTest, urlDecodeFailing_PercentFollowedByNonHexCharacterFirstBy
 	UTF8String decoded = core::util::URLEncoding::urldecode(s);
 
 	UTF8String expectation("invalid?XString");
-	EXPECT_TRUE(decoded.equals(expectation));
+	ASSERT_TRUE(decoded.equals(expectation));
 }
 
 TEST_F(URLEncodingTest, urlDecodeFailing_OneCharacterMissingAtTheEnd)
@@ -104,7 +104,7 @@ TEST_F(URLEncodingTest, urlDecodeFailing_OneCharacterMissingAtTheEnd)
 	UTF8String decoded = core::util::URLEncoding::urldecode(s);
 
 	UTF8String expectation("invalidstring");
-	EXPECT_TRUE(decoded.equals(expectation));
+	ASSERT_TRUE(decoded.equals(expectation));
 }
 
 TEST_F(URLEncodingTest, urlDecodeFailing_BothCharactersMissingAtTheEnd)
@@ -113,7 +113,7 @@ TEST_F(URLEncodingTest, urlDecodeFailing_BothCharactersMissingAtTheEnd)
 	UTF8String decoded = core::util::URLEncoding::urldecode(s);
 
 	UTF8String expectation("invalidstring");
-	EXPECT_TRUE(decoded.equals(expectation));
+	ASSERT_TRUE(decoded.equals(expectation));
 }
 
 TEST_F(URLEncodingTest, urlEncodeDecodePercentSignPreserved)
@@ -123,6 +123,18 @@ TEST_F(URLEncodingTest, urlEncodeDecodePercentSignPreserved)
 	UTF8String encoded = core::util::URLEncoding::urlencode(s);
 	UTF8String decoded = core::util::URLEncoding::urldecode(encoded);
 
-	EXPECT_TRUE(decoded.equals(s));
+	ASSERT_TRUE(decoded.equals(s));
+}
 
+TEST_F(URLEncodingTest, itIsPossibleToMarkAdditionalCharactersAsReserved)
+{
+	// given
+	UTF8String input("0123456789-._~");
+	std::unordered_set<char> additionalReservedCharacters =  { '0', '_' };
+
+	// when
+	auto obtained = core::util::URLEncoding::urlencode(input, additionalReservedCharacters);
+
+	// then
+	ASSERT_EQ(obtained, "%30123456789-.%5F~");
 }


### PR DESCRIPTION
In certain places, deviceID and appID need to percent-encoded
(aka URL encoded).
In addition to regular URL encoding, underscores need
to be encoded as well, since they have a special meaning
in the backend.