### PR TITLE
Remove "Enable minimal rebuild" compiler flag /Gm

### DIFF
--- a/cmake/CompilerConfiguration.cmake
+++ b/cmake/CompilerConfiguration.cmake
@@ -31,8 +31,8 @@ if(MSVC)
     # setup compiler flags
     #c compiler
     set(OPEN_KIT_C_FLAGS /W4 /nologo /wd4251 )
-    set(OPEN_KIT_C_FLAGS_DEBUG /Zi /Od /Ob0 /Oi /GF- /Gm /Gy /RTC1)
-    set(OPEN_KIT_C_FLAGS_RELEASE /Zi /O2 /Ob2 /Oi /Ot /GF /Gm-)
+    set(OPEN_KIT_C_FLAGS_DEBUG /Zi /Od /Ob0 /Oi /GF- /Gy /RTC1)
+    set(OPEN_KIT_C_FLAGS_RELEASE /Zi /O2 /Ob2 /Oi /Ot /GF)
     #c++ compiler
     set(OPEN_KIT_CXX_FLAGS ${OPEN_KIT_C_FLAGS} )
     set(OPEN_KIT_CXX_FLAGS_DEBUG ${OPEN_KIT_C_FLAGS_DEBUG})


### PR DESCRIPTION
After updating to the latest Visual Studio Version,
the compiler gives a deprecation warning.

Flag has been removed.