### PR TITLE
BeaconSender thread was stopped too early

### DIFF
--- a/src/core/BeaconSender.cxx
+++ b/src/core/BeaconSender.cxx
@@ -51,7 +51,7 @@ bool BeaconSender::initialize()
 			mLogger->debug("BeaconSender thread started");
 		}
 
-		while (mBeaconSendingContext != nullptr && !mBeaconSendingContext->isInTerminalState() && !mShutdownTrigger)
+		while (mBeaconSendingContext != nullptr && !mBeaconSendingContext->isInTerminalState())
 		{
 			mBeaconSendingContext->executeCurrentState();
 		}


### PR DESCRIPTION
When shutdown was requested, a boolean flag was set
indicating to shutdown the BeaconSender thread.

Unfortunately this flag was also part of the condition
when executing states, therefore Flush was never executed
and sessions might not have been reported.