### PR TITLE
Do not log a warning, if session's IP is nullptr

### DIFF
--- a/src/protocol/Beacon.cxx
+++ b/src/protocol/Beacon.cxx
@@ -28,12 +28,12 @@
 
 using namespace protocol;
 
-Beacon::Beacon(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<caching::IBeaconCache> beaconCache, std::shared_ptr<configuration::Configuration> configuration, const core::UTF8String clientIPAddress, std::shared_ptr<providers::IThreadIDProvider> threadIDProvider, std::shared_ptr<providers::ITimingProvider> timingProvider)
+Beacon::Beacon(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<caching::IBeaconCache> beaconCache, std::shared_ptr<configuration::Configuration> configuration, const char* clientIPAddress, std::shared_ptr<providers::IThreadIDProvider> threadIDProvider, std::shared_ptr<providers::ITimingProvider> timingProvider)
 	: Beacon(logger, beaconCache, configuration, clientIPAddress, threadIDProvider, timingProvider, std::make_shared<providers::DefaultPRNGenerator>())
 {
 }
 
-Beacon::Beacon(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<caching::IBeaconCache> beaconCache, std::shared_ptr<configuration::Configuration> configuration, const core::UTF8String clientIPAddress, std::shared_ptr<providers::IThreadIDProvider> threadIDProvider, std::shared_ptr<providers::ITimingProvider> timingProvider, std::shared_ptr<providers::IPRNGenerator> randomGenerator)
+Beacon::Beacon(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<caching::IBeaconCache> beaconCache, std::shared_ptr<configuration::Configuration> configuration, const char* clientIPAddress, std::shared_ptr<providers::IThreadIDProvider> threadIDProvider, std::shared_ptr<providers::ITimingProvider> timingProvider, std::shared_ptr<providers::IPRNGenerator> randomGenerator)
 	: mLogger(logger)
 	, mConfiguration(configuration)
 	, mClientIPAddress(core::UTF8String(""))
@@ -50,15 +50,21 @@ Beacon::Beacon(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<caching
 	, mDeviceID("")
 	, mRandomGenerator(randomGenerator)
 {
-	if (core::util::InetAddressValidator::IsValidIP(clientIPAddress))
+	core::UTF8String internalClientIPAddress(clientIPAddress);
+	if (clientIPAddress == nullptr)
 	{
-		mClientIPAddress = clientIPAddress;
+		// A client IP address, which is a nullptr, is valid.
+		// The real IP address is determined on the server side.
+	}
+	else if (core::util::InetAddressValidator::IsValidIP(internalClientIPAddress))
+	{
+		mClientIPAddress = internalClientIPAddress;
 	}
 	else
 	{
 		if (logger->isWarningEnabled())
 		{
-			logger->warning("Beacon() - Client IP address validation failed: %s", clientIPAddress.getStringData().c_str());
+			logger->warning("Beacon() - Client IP address validation failed: %s", internalClientIPAddress.getStringData().c_str());
 		}
 	}
 
@@ -576,4 +582,9 @@ void Beacon::setBeaconConfiguration(std::shared_ptr<configuration::BeaconConfigu
 std::shared_ptr<configuration::BeaconConfiguration> Beacon::getBeaconConfiguration() const
 {
 	return std::atomic_load(&mBeaconConfiguration);
+}
+
+const core::UTF8String& Beacon::getClientIPAddress() const
+{
+	return mClientIPAddress;
 }

--- a/src/protocol/Beacon.h
+++ b/src/protocol/Beacon.h
@@ -53,7 +53,7 @@ namespace protocol
 		/// @param[in] timingProvider timing provider used to retrieve timestamps
 		///
 		Beacon(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<caching::IBeaconCache> beaconCache,
-			std::shared_ptr<configuration::Configuration> configuration, const core::UTF8String clientIPAddress,
+			std::shared_ptr<configuration::Configuration> configuration, const char* clientIPAddress,
 			std::shared_ptr<providers::IThreadIDProvider> threadIDProvider,
 			std::shared_ptr<providers::ITimingProvider> timingProvider);
 
@@ -68,7 +68,7 @@ namespace protocol
 		/// @param[in] randomGenerator random number generator
 		///
 		Beacon(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<caching::IBeaconCache> beaconCache,
-			std::shared_ptr<configuration::Configuration> configuration, const core::UTF8String clientIPAddress, 
+			std::shared_ptr<configuration::Configuration> configuration, const char* clientIPAddress,
 			std::shared_ptr<providers::IThreadIDProvider> threadIDProvider , 
 			std::shared_ptr<providers::ITimingProvider> timingProvider, 
 			std::shared_ptr<providers::IPRNGenerator> randomGenerator);
@@ -237,13 +237,13 @@ namespace protocol
 
 		///
 		/// Returns the session number.
-		/// @return session number
+		/// @returns session number
 		///
 		int32_t getSessionNumber() const;
 
 		///
 		/// Returns the device id
-		/// @return device id
+		/// @returns device id
 		///
 		const core::UTF8String& getDeviceID() const;
 
@@ -259,6 +259,12 @@ namespace protocol
 		///
 		std::shared_ptr<configuration::BeaconConfiguration> getBeaconConfiguration() const;
 
+		///
+		/// Get the client IP address.
+		/// @returns The client's IP address.
+		///
+		const core::UTF8String& getClientIPAddress() const;
+
 	private:
 		///
 		/// Serialization helper method for creating basic beacon protocol data.
@@ -268,13 +274,13 @@ namespace protocol
 
 		///
 		/// Serialization helper method for creating basic event data
-		/// @return Serialized data
+		/// @returns Serialized data
 		///
 		core::UTF8String createBasicEventData(EventType eventType, const core::UTF8String& eventName);
 
 		///
 		/// Serialization helper method for creating basic timestamp data.
-		/// @return Serialized data
+		/// @returns Serialized data
 		///
 		core::UTF8String createTimestampData();
 
@@ -284,7 +290,7 @@ namespace protocol
 		/// @param[in] name Event name
 		/// @param[in] parentActionID The ID of the action on which this event was reported.
 		/// @param[inout] eventTimestamp uint64_t var that will be filled with the event timestamp
-		/// @return The timestamp associated with the event(timestamp since session start time).
+		/// @returns The timestamp associated with the event(timestamp since session start time).
 		///
 		core::UTF8String buildEvent(EventType eventType, const core::UTF8String& name, int32_t parentActionID, uint64_t& eventTimestamp);
 
@@ -342,7 +348,7 @@ namespace protocol
 		///
 		/// Get a timestamp relative to the time this session (aka. beacon) was created.
 		/// @param[in] timestamp The absolute timestamp for which to get a relative one.
-		/// @return relative timestamp
+		/// @returns relative timestamp
 		///
 		int64_t getTimeSinceSessionStartTime(int64_t timestamp);
 
@@ -369,7 +375,7 @@ namespace protocol
 
 		///
 		/// Generate multiplicity data
-		/// @return the multiplicity data
+		/// @returns the multiplicity data
 		///
 		core::UTF8String createMultiplicityData();
 

--- a/test/core/ActionTest.cxx
+++ b/test/core/ActionTest.cxx
@@ -70,7 +70,7 @@ protected:
 		beaconCache = std::make_shared<caching::BeaconCache>(logger);
 
 		beaconSender = std::make_shared<core::BeaconSender>(logger, configuration, mockHTTPClientProvider, timingProvider);
-		mockBeacon = std::make_shared<testing::NiceMock<test::MockBeacon>>(logger, beaconCache, configuration, core::UTF8String(""), threadIDProvider, timingProvider);
+		mockBeacon = std::make_shared<testing::NiceMock<test::MockBeacon>>(logger, beaconCache, configuration, nullptr, threadIDProvider, timingProvider);
 
 		session = std::make_shared<core::Session>(logger, beaconSender, mockBeacon);
 	}

--- a/test/core/RootActionTest.cxx
+++ b/test/core/RootActionTest.cxx
@@ -69,7 +69,7 @@ protected:
 		beaconCache = std::make_shared<caching::BeaconCache>(logger);
 
 		beaconSender = std::make_shared<core::BeaconSender>(logger, configuration, mockHTTPClientProvider, timingProvider);
-		mockBeacon = std::make_shared<testing::NiceMock<test::MockBeacon>>(logger, beaconCache, configuration, core::UTF8String(""), threadIDProvider, timingProvider);
+		mockBeacon = std::make_shared<testing::NiceMock<test::MockBeacon>>(logger, beaconCache, configuration, nullptr, threadIDProvider, timingProvider);
 
 		session = std::make_shared<core::Session>(logger, beaconSender, mockBeacon);
 	}

--- a/test/core/SessionTest.cxx
+++ b/test/core/SessionTest.cxx
@@ -72,8 +72,8 @@ protected:
 		beaconCache = std::make_shared<caching::BeaconCache>(logger);
 
 		mockBeaconSender = std::make_shared<testing::StrictMock<test::MockBeaconSender>>(logger, configuration, mockHTTPClientProvider, timingProvider);
-		mockBeaconStrict = std::make_shared<testing::StrictMock<test::MockBeacon>>(logger, beaconCache, configuration, core::UTF8String(""), threadIDProvider, timingProvider);
-		mockBeaconNice = std::make_shared<testing::NiceMock<test::MockBeacon>>(logger, beaconCache, configuration, core::UTF8String(""), threadIDProvider, timingProvider);
+		mockBeaconStrict = std::make_shared<testing::StrictMock<test::MockBeacon>>(logger, beaconCache, configuration, nullptr, threadIDProvider, timingProvider);
+		mockBeaconNice = std::make_shared<testing::NiceMock<test::MockBeacon>>(logger, beaconCache, configuration, nullptr, threadIDProvider, timingProvider);
 	}
 
 	void TearDown()

--- a/test/core/WebRequestTracerBaseTest.cxx
+++ b/test/core/WebRequestTracerBaseTest.cxx
@@ -71,8 +71,8 @@ protected:
 		beaconCache = std::make_shared<caching::BeaconCache>(logger);
 
 		beaconSender = std::make_shared<core::BeaconSender>(logger, configuration, mockHTTPClientProvider, timingProvider);
-		mockBeaconStrict = std::make_shared<testing::StrictMock<test::MockBeacon>>(logger, beaconCache, configuration, core::UTF8String(""), threadIDProvider, timingProvider);	
-		mockBeaconNice = std::make_shared<testing::NiceMock<test::MockBeacon>>(logger, beaconCache, configuration, core::UTF8String(""), threadIDProvider, timingProvider);	
+		mockBeaconStrict = std::make_shared<testing::StrictMock<test::MockBeacon>>(logger, beaconCache, configuration, nullptr, threadIDProvider, timingProvider);	
+		mockBeaconNice = std::make_shared<testing::NiceMock<test::MockBeacon>>(logger, beaconCache, configuration, nullptr, threadIDProvider, timingProvider);	
 
 		action = std::make_shared<core::Action>(logger, mockBeaconNice, core::UTF8String("test action"));
 	}

--- a/test/core/WebRequestTracerStringURLTest.cxx
+++ b/test/core/WebRequestTracerStringURLTest.cxx
@@ -55,12 +55,13 @@ protected:
 		auto beaconCache = std::make_shared<caching::BeaconCache>(logger);
 
 		logger = std::make_shared<core::util::DefaultLogger>(devNull, openkit::LogLevel::LOG_LEVEL_DEBUG);
-		mockBeacon = std::make_shared<testing::NiceMock<test::MockBeacon>>(logger, beaconCache, configuration, core::UTF8String(""), threadIDProvider, timingProvider);
+		mockBeacon = std::make_shared<testing::NiceMock<test::MockBeacon>>(logger, beaconCache, configuration, nullptr, threadIDProvider, timingProvider);
 	}
 
 	virtual void TearDown() override
 	{
 		logger = nullptr;
+		mockBeacon = nullptr;
 	}
 
 	std::ostringstream devNull;

--- a/test/protocol/MockBeacon.h
+++ b/test/protocol/MockBeacon.h
@@ -35,7 +35,7 @@ namespace test {
 	class MockBeacon : public protocol::Beacon
 	{
 	public:
-		MockBeacon(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<caching::BeaconCache> beaconCache, std::shared_ptr<configuration::Configuration> configuration, const core::UTF8String clientIPAddress, std::shared_ptr<providers::IThreadIDProvider> threadIDProvider, std::shared_ptr<providers::ITimingProvider> timingProvider)
+		MockBeacon(std::shared_ptr<openkit::ILogger> logger, std::shared_ptr<caching::BeaconCache> beaconCache, std::shared_ptr<configuration::Configuration> configuration, const char* clientIPAddress, std::shared_ptr<providers::IThreadIDProvider> threadIDProvider, std::shared_ptr<providers::ITimingProvider> timingProvider)
 			: Beacon(logger, beaconCache, configuration, clientIPAddress, threadIDProvider, timingProvider)
 		{
 


### PR DESCRIPTION
Since OpenKit does allow nullptr, no warning log
shall be issued in this case.
The server will try to determine the client's IP address, if
nullptr is used.